### PR TITLE
Adding missing module dependency whatwg-fetch

### DIFF
--- a/skeleton/client/package.json
+++ b/skeleton/client/package.json
@@ -8,7 +8,8 @@
   "dependencies": {
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
-    "react-bootstrap": "^0.30.5"
+    "react-bootstrap": "^0.30.5",
+    "whatwg-fetch":"^2.0.2"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
There is a missing dependency in the current react profile preventing the client app to work.